### PR TITLE
Support for prefix property

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -43,6 +43,7 @@ module.exports = function(args) {
         key: args.aws_key,
         secret: args.aws_secret,
         bucket: args.bucket,
+        prefix: args.prefix,
         concurrency: args.concurrency,
         region: args.region
       }).on('data', function(file) {


### PR DESCRIPTION
Added support for prefix property in _config.yml to allow uploading the hexo project to specific folder of the S3 bucket. Makes it handy when you are trying to create hexo blog as sub-site of your main site (which can be non-hexo).
