### PR TITLE
Pass headers to s3-sync to be able to set metadata in objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,28 @@ deploy:
   aws_secret: <AWS secret key>  // Optional, if the environment variable `AWS_SECRET` is set
   concurrency: <number of connections> // Optional
   region: <region>  // Optional, see https://github.com/LearnBoost/knox#region
+  headers: <headers in JSON format> // pass any headers to S3, usefull for metadata cache setting of Hexo assets
+```
+#### Example: header Cache-Control
+
+``` yaml
+deploy:
+  type: s3-cloudfront
+  bucket: my-site-bucket
+  cf_distribution: mydistributionid
+  headers: {CacheControl: 'max-age=604800, public'}
+```
+
+This will set "Cache-Control" header in every file deployed to max-age 1 week. This solves "Leverage browser caching" on most page speed analyzers. For custom metadata use:
+
+``` yaml
+  headers: {Metadata : { x-amz-meta-mykey: "my value" }}
 ```
 
 ## Contributors
 
 - Josh Strange ([joshstrange](https://github.com/joshstrange); original implementation)
+- Josenivaldo Benito Jr. ([JrBenito](https://github.com/jrbenito))
 
 ## License
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -16,6 +16,8 @@ module.exports = function(args) {
   var publicDir = this.config.public_dir;
   var log = this.log;
 
+  var customHeaders = args.hearders || {};
+
   if (!args.bucket || !config.s3Options.accessKeyId || !config.s3Options.secretAccessKey) {
     var help = '';
 
@@ -27,8 +29,9 @@ module.exports = function(args) {
     help += '    [aws_key]: <aws_key>        # Optional, if provided as environment variable\n';
     help += '    [aws_secret]: <aws_secret>  # Optional, if provided as environment variable\n';
     help += '    [concurrency]: <concurrency>\n';
-    help += '    [region]: <region>          # See https://github.com/LearnBoost/knox#region\n\n',
-      help += 'For more help, you can check the docs: ' + chalk.underline('https://github.com/nt3rp/hexo-deployer-s3');
+    help += '    [region]: <region>          # See https://github.com/LearnBoost/knox#region\n',
+    help += '    [headers]: <JSON headers>   # Optional, see README.md file\n\n';
+    help += 'For more help, you can check the docs: ' + chalk.underline('https://github.com/nt3rp/hexo-deployer-s3');
 
     console.log(help);
     return;
@@ -38,7 +41,8 @@ module.exports = function(args) {
     localDir: publicDir,
     deleteRemoved: true,
     s3Params: {
-      Bucket: args.bucket
+      Bucket: args.bucket,
+      headers: customHeaders
     }
   }
 


### PR DESCRIPTION
s3-sync has the ability to receive headers as arguments and pass them to
AWS S3 as metadata headers. This modification proposes to set headers at
configuration so they are written in the objects when deploying.

Main motivation is to be able to pass CacheControl header and have
Cache-Control set for objects ovoiding "Leverage Browser Caching"
throwed by page speed analyzers.

Attention: Metadata are written equal to all objects (files) stored to
S3 and there is no way to tailor it by file type at this moment.

Signed-off-by: Josenivaldo Benito Jr jrbenito@benito.qsl.br
