### PR TITLE
Pass headers to s3-sync to be able to set metadata in objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,28 @@ deploy:
   aws_secret: <AWS secret key>  // Optional, if the environment variable `AWS_SECRET` is set
   concurrency: <number of connections> // Optional
   region: <region>  // Optional, see https://github.com/LearnBoost/knox#region
+  headers: <headers in JSON format> // pass any headers to S3, usefull for metadata cache setting of Hexo assets
+```
+#### Example: header Cache-Control
+
+``` yaml
+deploy:
+  type: s3-cloudfront
+  bucket: my-site-bucket
+  cf_distribution: mydistributionid
+  headers: {CacheControl: 'max-age=604800, public'}
+```
+
+This will set "Cache-Control" header in every file deployed to max-age 1 week. This solves "Leverage browser caching" on most page speed analyzers. For custom metadata use:
+
+``` yaml
+  headers: {Metadata : { x-amz-meta-mykey: "my value" }}
 ```
 
 ## Contributors
 
 - Josh Strange ([joshstrange](https://github.com/joshstrange); original implementation)
+- Josenivaldo Benito Jr. ([JrBenito](https://github.com/jrbenito))
 
 ## License
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -1,5 +1,6 @@
 var s3 = require('s3');
 var chalk = require('chalk');
+var xtend = require('xtend');
 
 module.exports = function(args) {
 
@@ -16,6 +17,8 @@ module.exports = function(args) {
   var publicDir = this.config.public_dir;
   var log = this.log;
 
+  var customHeaders = args.headers || {};
+
   if (!args.bucket || !config.s3Options.accessKeyId || !config.s3Options.secretAccessKey) {
     var help = '';
 
@@ -27,8 +30,9 @@ module.exports = function(args) {
     help += '    [aws_key]: <aws_key>        # Optional, if provided as environment variable\n';
     help += '    [aws_secret]: <aws_secret>  # Optional, if provided as environment variable\n';
     help += '    [concurrency]: <concurrency>\n';
-    help += '    [region]: <region>          # See https://github.com/LearnBoost/knox#region\n\n',
-      help += 'For more help, you can check the docs: ' + chalk.underline('https://github.com/nt3rp/hexo-deployer-s3');
+    help += '    [region]: <region>          # See https://github.com/LearnBoost/knox#region\n',
+    help += '    [headers]: <JSON headers>   # Optional, see README.md file\n\n';
+    help += 'For more help, you can check the docs: ' + chalk.underline('https://github.com/nt3rp/hexo-deployer-s3');
 
     console.log(help);
     return;
@@ -37,9 +41,9 @@ module.exports = function(args) {
   var params = {
     localDir: publicDir,
     deleteRemoved: true,
-    s3Params: {
+    s3Params: xtend({
       Bucket: args.bucket
-    }
+    },customHeaders)
   }
 
   var uploader = client.uploadDir(params);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     {
       "name": "Jack Guy",
       "email": "jack@thatguyjackguy.com"
+    },
+    {
+      "name": "Josenivaldo Benito Jr.",
+      "email": "jrbenito@benito.qsl.br"
     }
   ],
   "repository": {
@@ -32,6 +36,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "s3": "^4.4.0"
+    "s3": "^4.4.0",
+    "xtend": "^4.0.1"
   }
 }


### PR DESCRIPTION
s3-sync has the ability to receive headers as arguments and pass them to
AWS S3 as metadata headers. This modification proposes to set headers at
configuration so they are written in the objects when deploying.

Main motivation is to be able to pass CacheControl header and have
Cache-Control set for objects ovoiding "Leverage Browser Caching"
throwed by page speed analyzers.

Attention: Metadata are written equal to all objects (files) stored to
S3 and there is no way to tailor it by file type at this moment.

Signed-off-by: Josenivaldo Benito Jr jrbenito@benito.qsl.br
