### PR TITLE
use default amazon env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hexo-deployer-s3 
+# hexo-deployer-s3
 
 Amazon S3 deployer plugin for [Hexo](http://hexo.io/)
 
@@ -17,8 +17,8 @@ You can configure this plugin in `_config.yml`.
 deploy:
   type: s3
   bucket: <S3 bucket>
-  aws_key: <AWS id key>  // Optional, if the environment variable `AWS_KEY` is set
-  aws_secret: <AWS secret key>  // Optional, if the environment variable `AWS_SECRET` is set
+  aws_key: <AWS id key>  // Optional, if the environment variable `AWS_ACCESS_KEY_ID` is set
+  aws_secret: <AWS secret key>  // Optional, if the environment variable `AWS_SECRET_ACCESS_KEY` is set
   concurrency: <number of connections> // Optional
   region: <region>  // Optional, see https://github.com/LearnBoost/knox#region
 ```

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -6,8 +6,8 @@ module.exports = function(args) {
   var config = {
     maxAsyncS3: args.concurrency,
     s3Options: {
-      accessKeyId: args.aws_key || process.env.AWS_KEY,
-      secretAccessKey: args.aws_secret || process.env.AWS_SECRET,
+      accessKeyId: args.aws_key || process.env.AWS_ACCESS_KEY_ID || process.env.AWS_KEY,
+      secretAccessKey: args.aws_secret || process.env.AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET,
       region: args.region
     }
   };
@@ -44,7 +44,7 @@ module.exports = function(args) {
 
   var uploader = client.uploadDir(params);
   log.info('Uploading...');
-  
+
   return uploader
     .on('progress', function() {
       //   log.info(uploader.progressAmount + ' / ' + uploader.progressTotal);


### PR DESCRIPTION
currently, the plugin is looking for AWS environmental variables via `AWS_KEY` and `AWS_SECRET`. This isn't the standard.

This pull request adds functionality to _also_ look for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as these are the keys being injected by amazon services

see http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html