### PR TITLE
added support for prefix option to allow deploying to subdirectories

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -31,7 +31,8 @@ module.exports = function(args) {
     help += '    [aws_secret]: <aws_secret>  # Optional, if provided as environment variable\n';
     help += '    [concurrency]: <concurrency>\n';
     help += '    [region]: <region>          # See https://github.com/LearnBoost/knox#region\n',
-    help += '    [headers]: <JSON headers>   # Optional, see README.md file\n\n';
+    help += '    [headers]: <JSON headers>   # Optional, see README.md file\n';
+    help += '    [prefix]: <prefix>          # Optional, prefix ending in /\n\n';
     help += 'For more help, you can check the docs: ' + chalk.underline('https://github.com/nt3rp/hexo-deployer-s3');
 
     console.log(help);
@@ -42,7 +43,8 @@ module.exports = function(args) {
     localDir: publicDir,
     deleteRemoved: true,
     s3Params: xtend({
-      Bucket: args.bucket
+      Bucket: args.bucket,
+      Prefix: args.prefix
     },customHeaders)
   }
 


### PR DESCRIPTION
Added support for prefix option to allow for deploying to a subdirectory.

There's already a pull request ( https://github.com/nt3rp/hexo-deployer-s3/pull/7 ) for this, but conflicts still haven't been resolved since June 2016. Since I needed the prefix option today I went ahead and made the change.