### PR TITLE
fix readme: remove cloudfront config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ deploy:
 
 ``` yaml
 deploy:
-  type: s3-cloudfront
+  type: s3
   bucket: my-site-bucket
-  cf_distribution: mydistributionid
   headers: {CacheControl: 'max-age=604800, public'}
 ```
 


### PR DESCRIPTION
It stated s3-cloudfront. Seems to be a 'copy paste' issue from a different repo's README.